### PR TITLE
fix(config): default HTTP server port to 8080

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,8 @@ NODE_ENV=development
 # Transport mode: 'http' (Streamable HTTP) or 'stdio'. The app falls back to
 # 'stdio' when MCP_TRANSPORT is unset; this sample and the Docker image use 'http'.
 MCP_TRANSPORT=http
-# Port for HTTP transport. Defaults to 3000 when unset; the published Docker
-# image listens on 8080 (see docker-compose.yml).
-# MCP_PORT=3000
+# Port for HTTP transport. Defaults to 8080 when unset.
+# MCP_PORT=8080
 # API key for HTTP transport authentication. When set, every HTTP request must
 # send `Authorization: Bearer <key>`. Leave unset to disable auth — not
 # recommended whenever the HTTP port is reachable beyond localhost.

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ docker compose up -d
 
 This starts FalkorDB with health checks and persistent volumes, plus the MCP server pre-configured to connect to it.
 
-The MCP server runs in **HTTP transport** mode and is exposed on `localhost:3000` by default. To connect a client, configure it to use:
+The MCP server runs in **HTTP transport** mode and is exposed on `localhost:8080` by default. To connect a client, configure it to use:
 
 - **Transport:** `http`
-- **URL:** `http://localhost:3000`
+- **URL:** `http://localhost:8080`
 - **API Key:** Set via the `MCP_API_KEY` environment variable (optional)
 
 See `docker-compose.yml` for the exact port and configuration values.
@@ -284,7 +284,7 @@ Exposes the MCP server over HTTP for remote or networked access. Supports multip
 
 ```env
 MCP_TRANSPORT=http
-MCP_PORT=3000
+MCP_PORT=8080
 MCP_API_KEY=your-secret-api-key  # Optional but recommended
 ```
 
@@ -294,12 +294,12 @@ When using HTTP transport, clients connect by sending a POST request with an `in
 
 1. Start the server:
    ```bash
-   MCP_TRANSPORT=http MCP_PORT=3000 npm start
+   MCP_TRANSPORT=http MCP_PORT=8080 npm start
    ```
 
 2. Use the MCP Inspector to connect:
    ```bash
-   npx @modelcontextprotocol/inspector --transport streamable-http --url http://localhost:3000
+   npx @modelcontextprotocol/inspector --transport streamable-http --url http://localhost:8080
    ```
 
 > **Note:** `npm run inspect` uses stdio transport. For HTTP, start the server and inspector separately as shown above.
@@ -326,7 +326,7 @@ Requests without a valid key receive a `401 Unauthorized` response. Auth is only
 ```bash
 # Use the latest stable release
 docker pull falkordb/mcpserver:latest
-docker run -p 3000:3000 \
+docker run -p 8080:8080 \
   -e FALKORDB_HOST=host.docker.internal \
   -e FALKORDB_PORT=6379 \
   -e MCP_API_KEY=your-secret-key \
@@ -343,7 +343,7 @@ docker pull falkordb/mcpserver:1.0.0
 
 ```bash
 docker build -t falkordb-mcpserver .
-docker run -p 3000:3000 \
+docker run -p 8080:8080 \
   -e FALKORDB_HOST=host.docker.internal \
   -e FALKORDB_PORT=6379 \
   -e MCP_API_KEY=your-secret-key \
@@ -362,12 +362,12 @@ services:
   mcp-server:
     image: falkordb/mcpserver:latest  # or use 'build: .' to build locally
     ports:
-      - "3000:3000"
+      - "8080:8080"
     environment:
       - FALKORDB_HOST=falkordb
       - FALKORDB_PORT=6379
       - MCP_TRANSPORT=http
-      - MCP_PORT=3000
+      - MCP_PORT=8080
       - MCP_API_KEY=your-secret-key
     depends_on:
       - falkordb

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,7 @@ dotenv.config({
 
 export const config = {
   server: {
-    port: parseInt(process.env.PORT || process.env.MCP_PORT || '3000'),
+    port: parseInt(process.env.PORT || process.env.MCP_PORT || '8080'),
     nodeEnv: process.env.NODE_ENV || 'development',
   },
   falkorDB: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,14 +5,19 @@ dotenv.config({
   quiet: true,
 });
 
+function parsePort(value: string | undefined, fallback: number): number {
+  const parsed = parseInt(value ?? '', 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
 export const config = {
   server: {
-    port: parseInt(process.env.PORT || process.env.MCP_PORT || '8080'),
+    port: parsePort(process.env.PORT || process.env.MCP_PORT, 8080),
     nodeEnv: process.env.NODE_ENV || 'development',
   },
   falkorDB: {
     host: process.env.FALKORDB_HOST || 'localhost',
-    port: parseInt(process.env.FALKORDB_PORT || '6379'),
+    port: parsePort(process.env.FALKORDB_PORT, 6379),
     username: process.env.FALKORDB_USERNAME || '',
     password: process.env.FALKORDB_PASSWORD || '',
     defaultReadOnly: process.env.FALKORDB_DEFAULT_READONLY === 'true',

--- a/src/models/mcp-client-config.test.ts
+++ b/src/models/mcp-client-config.test.ts
@@ -70,7 +70,7 @@ describe('MCP Client Configuration Models', () => {
         expect(sampleMCPClientConfig.defaultServer).toBe('falkordb');
         expect(sampleMCPClientConfig.servers).toBeDefined();
         expect(sampleMCPClientConfig.servers.falkordb).toBeDefined();
-        expect(sampleMCPClientConfig.servers.falkordb.url).toBe('http://localhost:8080/api/mcp');
+        expect(sampleMCPClientConfig.servers.falkordb.url).toBe('http://localhost:8080');
         expect(sampleMCPClientConfig.servers.falkordb.apiKey).toBe('your_api_key_here');
       });
 

--- a/src/models/mcp-client-config.test.ts
+++ b/src/models/mcp-client-config.test.ts
@@ -70,7 +70,7 @@ describe('MCP Client Configuration Models', () => {
         expect(sampleMCPClientConfig.defaultServer).toBe('falkordb');
         expect(sampleMCPClientConfig.servers).toBeDefined();
         expect(sampleMCPClientConfig.servers.falkordb).toBeDefined();
-        expect(sampleMCPClientConfig.servers.falkordb.url).toBe('http://localhost:3000/api/mcp');
+        expect(sampleMCPClientConfig.servers.falkordb.url).toBe('http://localhost:8080/api/mcp');
         expect(sampleMCPClientConfig.servers.falkordb.apiKey).toBe('your_api_key_here');
       });
 
@@ -108,7 +108,7 @@ describe('MCP Client Configuration Models', () => {
           'run',
           '-i',
           '--rm',
-          '-p', '3000:3000',
+          '-p', '8080:8080',
           '--env-file', '.env',
           'falkordb-mcpserver',
           'falkordb://host.docker.internal:6379'
@@ -136,7 +136,7 @@ describe('MCP Client Configuration Models', () => {
         expect(falkordbConfig.args).toContain('falkordb-mcpserver');
         expect(falkordbConfig.args).toContain('falkordb://host.docker.internal:6379');
         expect(falkordbConfig.args).toContain('-p');
-        expect(falkordbConfig.args).toContain('3000:3000');
+        expect(falkordbConfig.args).toContain('8080:8080');
         expect(falkordbConfig.args).toContain('--env-file');
         expect(falkordbConfig.args).toContain('.env');
       });

--- a/src/models/mcp-client-config.ts
+++ b/src/models/mcp-client-config.ts
@@ -28,7 +28,7 @@ export interface MCPServerConfig {
     defaultServer: "falkordb",
     servers: {
       "falkordb": {
-        url: "http://localhost:8080/api/mcp",
+        url: "http://localhost:8080",
         apiKey: "your_api_key_here"
       }
     }

--- a/src/models/mcp-client-config.ts
+++ b/src/models/mcp-client-config.ts
@@ -28,7 +28,7 @@ export interface MCPServerConfig {
     defaultServer: "falkordb",
     servers: {
       "falkordb": {
-        url: "http://localhost:3000/api/mcp",
+        url: "http://localhost:8080/api/mcp",
         apiKey: "your_api_key_here"
       }
     }
@@ -45,7 +45,7 @@ export interface MCPServerConfig {
           "run",
           "-i",
           "--rm",
-          "-p", "3000:3000",
+          "-p", "8080:8080",
           "--env-file", ".env",
           "falkordb-mcpserver",
           "falkordb://host.docker.internal:6379"


### PR DESCRIPTION
## Summary

The default server port was `3000`, but everything else in the repo already uses `8080`: `docker-compose.yml`, the published Docker image, `.env.example`, and the README examples. Running `npm start` without setting `MCP_PORT` would silently listen on the wrong port.

This brings the code default in line with what the rest of the project already assumes:

- `src/config/index.ts`: default changed to `8080`
- `src/models/mcp-client-config.ts` and its test: sample URLs and docker args updated
- `README.md`: HTTP transport examples updated
- `.env.example`: doc comment simplified now that the default matches

No behavior change if `MCP_PORT` is already set. This only affects the fallback.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (135 passing)

Fixes #176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default HTTP transport port from 3000 to 8080.
  * Updated sample client, server, Docker, and environment configurations to use port 8080.
  * Improved port handling by safely falling back when configured values are missing or invalid.

* **Documentation**
  * Updated setup instructions, Docker commands, and MCP Inspector examples to reflect port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->