### PR TITLE
feat(docker): make web UI and MCP server bind address configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,11 @@ MCP_TRANSPORT=http
 # Port for HTTP transport. Defaults to 8080 when unset.
 # MCP_PORT=8080
 
-# Interface the MCP server is published on.
+# Docker Compose only: host interface the MCP server's published port binds to.
+# This does NOT change what the server itself listens on inside the container —
+# it always listens on every interface there. Outside Compose (e.g. running
+# `npm start` directly on a host) this variable has no effect at all, and the
+# server is reachable from the LAN with no auth unless MCP_API_KEY is set.
 # - A non-loopback value requires MCP_API_KEY, or the server refuses to start in HTTP mode.
 # - MCP clients must include the header `Authorization: Bearer <key>` when MCP_API_KEY is set.
 # MCP_BIND_ADDRESS=127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,13 @@ MCP_TRANSPORT=http
 # send `Authorization: Bearer <key>`. Leave unset to disable auth — not
 # recommended whenever the HTTP port is reachable beyond localhost.
 # MCP_API_KEY=your_mcp_api_key_here
-# Docker Compose only: interface the MCP server's published port binds to.
-# Defaults closed (127.0.0.1 — localhost only). Recognized as local: any
-# 127.0.0.0/8 address and ::1 (bracketed as [::1] or not) — anything else
-# (e.g. 0.0.0.0, a LAN address) requires MCP_API_KEY to also be set, or the
-# server refuses to start.
+# Declares the interface the MCP server is being published on. With Docker
+# Compose, this also controls the published port's bind address (see
+# docker-compose.yml); outside Compose it only feeds the check below. Defaults
+# closed (127.0.0.1 — localhost only). Recognized as local: any 127.0.0.0/8
+# address and ::1 (bracketed as [::1] or not) — anything else (e.g. 0.0.0.0,
+# a LAN address) requires MCP_API_KEY to also be set, or the server refuses
+# to start in HTTP mode.
 # MCP_BIND_ADDRESS=127.0.0.1
 
 # FalkorDB Configuration

--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,16 @@ MCP_TRANSPORT=http
 # MCP_API_KEY=your_mcp_api_key_here
 # Declares the interface the MCP server is being published on. With Docker
 # Compose, this also controls the published port's bind address (see
-# docker-compose.yml); outside Compose it only feeds the check below. Defaults
-# closed (127.0.0.1 — localhost only). Recognized as local: any 127.0.0.0/8
-# address and ::1 (bracketed as [::1] or not) — anything else (e.g. 0.0.0.0,
-# a LAN address) requires MCP_API_KEY to also be set, or the server refuses
-# to start in HTTP mode.
+# docker-compose.yml), which is where "defaults closed (localhost only)"
+# actually holds. Outside Compose, this variable does NOT change what
+# interface the Node process listens on (it always listens on all
+# interfaces) — it only feeds the startup check below, so a bare `node
+# dist/index.js` or `docker run` with a published wildcard port is not made
+# local-only by leaving this unset (tracked as a known gap: see
+# https://github.com/FalkorDB/FalkorDB-MCPServer/issues/192). Recognized as
+# local: any 127.0.0.0/8 address and ::1 (bracketed as [::1] or not) —
+# anything else (e.g. 0.0.0.0, a LAN address) requires MCP_API_KEY to also be
+# set, or the server refuses to start in HTTP mode.
 # MCP_BIND_ADDRESS=127.0.0.1
 
 # FalkorDB Configuration

--- a/.env.example
+++ b/.env.example
@@ -5,36 +5,25 @@ NODE_ENV=development
 # Transport mode: 'http' (Streamable HTTP) or 'stdio'. The app falls back to
 # 'stdio' when MCP_TRANSPORT is unset; this sample and the Docker image use 'http'.
 MCP_TRANSPORT=http
-# Port for HTTP transport. Defaults to 3000 when unset; the published Docker
-# image listens on 8080 (see docker-compose.yml).
+
+# Port for HTTP transport.
+# The published Docker image listens on 8080 (see docker-compose.yml).
 # MCP_PORT=3000
-# API key for HTTP transport authentication. When set, every HTTP request must
-# send `Authorization: Bearer <key>`. Leave unset to disable auth — not
-# recommended whenever the HTTP port is reachable beyond localhost.
-# MCP_API_KEY=your_mcp_api_key_here
-# Declares the interface the MCP server is being published on. With Docker
-# Compose, this also controls the published port's bind address (see
-# docker-compose.yml), which is where "defaults closed (localhost only)"
-# actually holds. Outside Compose, this variable does NOT change what
-# interface the Node process listens on (it always listens on all
-# interfaces) — it only feeds the startup check below, so a bare `node
-# dist/index.js` or `docker run` with a published wildcard port is not made
-# local-only by leaving this unset (tracked as a known gap: see
-# https://github.com/FalkorDB/FalkorDB-MCPServer/issues/192). Recognized as
-# local: any 127.0.0.0/8 address and ::1 (bracketed as [::1] or not) —
-# anything else (e.g. 0.0.0.0, a LAN address) requires MCP_API_KEY to also be
-# set, or the server refuses to start in HTTP mode.
+
+# Interface the MCP server is published on.
+# - A non-loopback value requires MCP_API_KEY, or the server refuses to start in HTTP mode.
+# - MCP clients must include the header `Authorization: Bearer <key>` when MCP_API_KEY is set.
 # MCP_BIND_ADDRESS=127.0.0.1
+# MCP_API_KEY=your_mcp_api_key_here
+
 
 # FalkorDB Configuration
 # When using Docker Compose, set FALKORDB_HOST=falkordb (the service name)
 FALKORDB_HOST=localhost
 FALKORDB_PORT=6379
 FALKORDB_WEB_PORT=3000
-# Docker Compose only: interface the web UI's published port binds to. Defaults
-# closed (127.0.0.1 — localhost only) since the bundled UI has no auth of its
-# own. Set to 0.0.0.0 to reach it from other machines, e.g. on your LAN — only
-# do this on a trusted network, since anyone who can reach the port gets in.
+# Docker Compose only: interface the bundled web UI's published port binds to.
+# - The UI has no auth of its own — only set this to 0.0.0.0 on a trusted network.
 # FALKORDB_WEB_BIND_ADDRESS=127.0.0.1
 FALKORDB_USERNAME=
 FALKORDB_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,21 @@ MCP_TRANSPORT=http
 # send `Authorization: Bearer <key>`. Leave unset to disable auth — not
 # recommended whenever the HTTP port is reachable beyond localhost.
 # MCP_API_KEY=your_mcp_api_key_here
+# Docker Compose only: interface the MCP server's published port binds to.
+# Defaults closed (127.0.0.1 — localhost only). Set to 0.0.0.0 to reach it from
+# other machines, e.g. on your LAN — only do this with MCP_API_KEY also set.
+# MCP_BIND_ADDRESS=127.0.0.1
 
 # FalkorDB Configuration
 # When using Docker Compose, set FALKORDB_HOST=falkordb (the service name)
 FALKORDB_HOST=localhost
 FALKORDB_PORT=6379
 FALKORDB_WEB_PORT=3000
+# Docker Compose only: interface the web UI's published port binds to. Defaults
+# closed (127.0.0.1 — localhost only) since the bundled UI has no auth of its
+# own. Set to 0.0.0.0 to reach it from other machines, e.g. on your LAN — only
+# do this on a trusted network, since anyone who can reach the port gets in.
+# FALKORDB_WEB_BIND_ADDRESS=127.0.0.1
 FALKORDB_USERNAME=
 FALKORDB_PASSWORD=
 # Set to 'true' to use read-only queries by default (useful for replica instances)

--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,10 @@ MCP_TRANSPORT=http
 # recommended whenever the HTTP port is reachable beyond localhost.
 # MCP_API_KEY=your_mcp_api_key_here
 # Docker Compose only: interface the MCP server's published port binds to.
-# Defaults closed (127.0.0.1 — localhost only). Set to 0.0.0.0 to reach it from
-# other machines, e.g. on your LAN — only do this with MCP_API_KEY also set.
+# Defaults closed (127.0.0.1 — localhost only). Recognized as local: any
+# 127.0.0.0/8 address and ::1 (bracketed as [::1] or not) — anything else
+# (e.g. 0.0.0.0, a LAN address) requires MCP_API_KEY to also be set, or the
+# server refuses to start.
 # MCP_BIND_ADDRESS=127.0.0.1
 
 # FalkorDB Configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Project Guidelines
 
 ## Overview
-FalkorDB-MCPServer is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI models to interact with [FalkorDB](https://github.com/FalkorDB/FalkorDB) graph databases through natural language. It communicates via stdio transport and exposes graph operations as MCP tools.
+FalkorDB-MCPServer is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI models to interact with [FalkorDB](https://github.com/FalkorDB/FalkorDB) graph databases through natural language. It exposes graph operations as MCP tools over either of two transports, selected by `MCP_TRANSPORT`: **stdio** (the default) or **Streamable HTTP**.
 
 ## Build & Install
 ```bash
@@ -48,7 +48,7 @@ npm test             # ensure all tests pass
 ## Project Structure
 ```
 src/
-├── index.ts                    # MCP server entry point — tool/resource registration, stdio transport
+├── index.ts                    # MCP server entry point — tool/resource registration, transport startup
 ├── services/
 │   ├── falkordb.service.ts     # FalkorDB connection and graph operations (singleton)
 │   └── logger.service.ts       # Logging and MCP notifications
@@ -83,9 +83,9 @@ Schema-discovery tools (`get_graph_schema`, `get_node_schema`, `get_relationship
 - Services are exported as singleton instances
 - **FalkorDB Service** (`src/services/falkordb.service.ts`): manages connections, retries, and pooling; exposes `executeQuery()`, `executeReadOnlyQuery()`, `listGraphs()`, `deleteGraph()`
 
-### stdio Transport
-- The server communicates via **stdio**, not HTTP — console methods are redirected to stderr to prevent MCP protocol corruption
-- Build output in `dist/` is executed directly by MCP clients
+### Transports
+- **stdio** (default): console methods are redirected to stderr to prevent MCP protocol corruption on stdout. Build output in `dist/` is executed directly by MCP clients.
+- **HTTP** (`MCP_TRANSPORT=http`, `src/index.ts`'s `startHTTPServer()`): Streamable HTTP via `StreamableHTTPServerTransport`, one `McpServer` instance per session. Requests are Bearer-authenticated against `MCP_API_KEY` when it's set — unset, auth is disabled. Before listening, `enforceLocalBindWithoutApiKey()` (`src/utils/startup-guard.ts`) refuses to start if `MCP_BIND_ADDRESS` declares a non-loopback publish address with no `MCP_API_KEY` set (Docker Compose only — see the `MCP_BIND_ADDRESS` row below).
 
 ### Error Handling
 - MCP tool handlers use `errorHandler.toMcpErrorResult()` to sanitize errors before returning to clients (never throw from a tool handler)
@@ -103,7 +103,10 @@ Environment variables (copy `.env.example` to `.env`):
 | `FALKORDB_USERNAME` | — | Optional authentication |
 | `FALKORDB_PASSWORD` | — | Optional authentication |
 | `FALKORDB_DEFAULT_READONLY` | `false` | Set to 'true' for read-only mode (useful for replicas) |
+| `MCP_TRANSPORT` | `stdio` | `stdio` or `http` — selects which transport `src/index.ts` starts |
+| `MCP_API_KEY` | — | Bearer token required on HTTP requests when set; HTTP auth is disabled when unset. Ignored in stdio mode |
 | `MCP_BIND_ADDRESS` | `127.0.0.1` | Interface the MCP server is published on (Docker Compose: also the published port's bind address). Non-loopback values require `MCP_API_KEY` to be set, or the server refuses to start in HTTP mode |
+| `FALKORDB_WEB_BIND_ADDRESS` | `127.0.0.1` | Docker Compose only: interface the bundled FalkorDB web UI's published port binds to. The web UI has no auth of its own, so this is a manual, unguarded opt-in with no equivalent startup check |
 
 ## MCP Client Integration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Environment variables (copy `.env.example` to `.env`):
 | `FALKORDB_USERNAME` | — | Optional authentication |
 | `FALKORDB_PASSWORD` | — | Optional authentication |
 | `FALKORDB_DEFAULT_READONLY` | `false` | Set to 'true' for read-only mode (useful for replicas) |
+| `MCP_BIND_ADDRESS` | `127.0.0.1` | Interface the MCP server is published on (Docker Compose: also the published port's bind address). Non-loopback values require `MCP_API_KEY` to be set, or the server refuses to start in HTTP mode |
 
 ## MCP Client Integration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ src/
 │   ├── mcp.types.ts            # MCP protocol interfaces
 │   └── mcp-client-config.ts    # Configuration models
 └── utils/
-    └── connection-parser.ts    # Utility functions
+    ├── connection-parser.ts    # Utility functions
+    ├── bind-address.ts         # Loopback classification for MCP_BIND_ADDRESS
+    └── startup-guard.ts        # Refuses unauthenticated non-loopback HTTP startup
 ```
 
 ## Architecture Patterns
@@ -84,8 +86,8 @@ Schema-discovery tools (`get_graph_schema`, `get_node_schema`, `get_relationship
 - **FalkorDB Service** (`src/services/falkordb.service.ts`): manages connections, retries, and pooling; exposes `executeQuery()`, `executeReadOnlyQuery()`, `listGraphs()`, `deleteGraph()`
 
 ### Transports
-- **stdio** (default): console methods are redirected to stderr to prevent MCP protocol corruption on stdout. Build output in `dist/` is executed directly by MCP clients.
-- **HTTP** (`MCP_TRANSPORT=http`, `src/index.ts`'s `startHTTPServer()`): Streamable HTTP via `StreamableHTTPServerTransport`, one `McpServer` instance per session. Requests are Bearer-authenticated against `MCP_API_KEY` when it's set — unset, auth is disabled. Before listening, `enforceLocalBindWithoutApiKey()` (`src/utils/startup-guard.ts`) refuses to start if `MCP_BIND_ADDRESS` declares a non-loopback publish address with no `MCP_API_KEY` set (Docker Compose only — see the `MCP_BIND_ADDRESS` row below).
+- **stdio** (default): Build output in `dist/` is executed directly by MCP clients.
+- **HTTP** (`MCP_TRANSPORT=http`, `src/index.ts`'s `startHTTPServer()`): Streamable HTTP via `StreamableHTTPServerTransport`, one `McpServer` instance per session. Requests are Bearer-authenticated against `MCP_API_KEY` when it's set — unset, auth is disabled. Before listening, `enforceLocalBindWithoutApiKey()` (`src/utils/startup-guard.ts`) refuses to start whenever `MCP_BIND_ADDRESS` declares a non-loopback address with no `MCP_API_KEY` set — this runs unconditionally in every HTTP deployment, not only under Docker Compose (see the `MCP_BIND_ADDRESS` row below for what the variable actually controls).
 
 ### Error Handling
 - MCP tool handlers use `errorHandler.toMcpErrorResult()` to sanitize errors before returning to clients (never throw from a tool handler)
@@ -105,7 +107,7 @@ Environment variables (copy `.env.example` to `.env`):
 | `FALKORDB_DEFAULT_READONLY` | `false` | Set to 'true' for read-only mode (useful for replicas) |
 | `MCP_TRANSPORT` | `stdio` | `stdio` or `http` — selects which transport `src/index.ts` starts |
 | `MCP_API_KEY` | — | Bearer token required on HTTP requests when set; HTTP auth is disabled when unset. Ignored in stdio mode |
-| `MCP_BIND_ADDRESS` | `127.0.0.1` | Interface the MCP server is published on (Docker Compose: also the published port's bind address). Non-loopback values require `MCP_API_KEY` to be set, or the server refuses to start in HTTP mode |
+| `MCP_BIND_ADDRESS` | `127.0.0.1` | Docker Compose only: host interface the MCP server's published port binds to. Does not change what the server listens on inside the container (always every interface) and has no effect outside Compose. Non-loopback values require `MCP_API_KEY` to be set, or the server refuses to start in HTTP mode |
 | `FALKORDB_WEB_BIND_ADDRESS` | `127.0.0.1` | Docker Compose only: interface the bundled FalkorDB web UI's published port binds to. The web UI has no auth of its own, so this is a manual, unguarded opt-in with no equivalent startup check |
 
 ## MCP Client Integration

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The MCP server runs in **HTTP transport** mode and is exposed on `localhost:3000
 
 - **Transport:** `http`
 - **URL:** `http://localhost:3000`
-- **API Key:** Set via the `MCP_API_KEY` environment variable (optional)
+- **API Key:** Set via the `MCP_API_KEY` environment variable — optional for the default localhost-only setup, required if you set `MCP_BIND_ADDRESS` to a non-local address (see below)
 
 Both the MCP server's and the web UI's published ports are bound to `127.0.0.1` by default — reachable only from the machine running Docker Compose. To reach either from another machine (e.g. over a LAN), set `MCP_BIND_ADDRESS` / `FALKORDB_WEB_BIND_ADDRESS` to `0.0.0.0` in `.env`. The MCP server refuses to start with a non-local `MCP_BIND_ADDRESS` unless `MCP_API_KEY` is also set, since that combination would otherwise be an unauthenticated endpoint exposed to the network; the web UI has no auth of its own, so exposing it is a manual, unguarded opt-in.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ The MCP server runs in **HTTP transport** mode and is exposed on `localhost:3000
 - **URL:** `http://localhost:3000`
 - **API Key:** Set via the `MCP_API_KEY` environment variable (optional)
 
-See `docker-compose.yml` for the exact port and configuration values.
+Both the MCP server's and the web UI's published ports are bound to `127.0.0.1` by default — reachable only from the machine running Docker Compose. To reach either from another machine (e.g. over a LAN), set `MCP_BIND_ADDRESS` / `FALKORDB_WEB_BIND_ADDRESS` to `0.0.0.0` in `.env`. The MCP server refuses to start with a non-local `MCP_BIND_ADDRESS` unless `MCP_API_KEY` is also set, since that combination would otherwise be an unauthenticated endpoint exposed to the network; the web UI has no auth of its own, so exposing it is a manual, unguarded opt-in.
+
+See `docker-compose.yml` and `.env.example` for the exact port and configuration values.
 
 ### Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,21 +52,10 @@ services:
     # Bound to 127.0.0.1 by default: in HTTP mode the server only enforces Bearer
     # auth when MCP_API_KEY is set, so a wildcard bind would expose an
     # unauthenticated endpoint. Set MCP_BIND_ADDRESS=0.0.0.0 in .env (and set
-    # MCP_API_KEY) to reach it from other hosts — the entrypoint below refuses
-    # to start otherwise.
+    # MCP_API_KEY) to reach it from other hosts — the server itself refuses to
+    # start otherwise (see enforceLocalBindWithoutApiKey() in src/index.ts).
     ports:
       - "${MCP_BIND_ADDRESS:-127.0.0.1}:${MCP_PORT:-8080}:8080"
-    # Refuse to start if MCP_BIND_ADDRESS opts into a non-local bind without
-    # MCP_API_KEY set — that combination is an unauthenticated HTTP endpoint
-    # exposed beyond localhost. Local-only binding (the default) is unaffected.
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        if [ "$$MCP_TRANSPORT" = "http" ] && [ "$$MCP_BIND_ADDRESS" != "127.0.0.1" ] && [ "$$MCP_BIND_ADDRESS" != "::1" ] && [ -z "$$MCP_API_KEY" ]; then
-          echo "MCP_BIND_ADDRESS=$$MCP_BIND_ADDRESS exposes the MCP server beyond localhost, but MCP_API_KEY is unset. Refusing to start an unauthenticated HTTP endpoint on the network. Set MCP_API_KEY in .env, or leave MCP_BIND_ADDRESS at 127.0.0.1." >&2
-          exit 1
-        fi
-        exec node dist/index.js
     environment:
       - NODE_ENV=production
       - MCP_TRANSPORT=${MCP_TRANSPORT:-http}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,14 +52,27 @@ services:
     # Bound to 127.0.0.1 by default: in HTTP mode the server only enforces Bearer
     # auth when MCP_API_KEY is set, so a wildcard bind would expose an
     # unauthenticated endpoint. Set MCP_BIND_ADDRESS=0.0.0.0 in .env (and set
-    # MCP_API_KEY) to reach it from other hosts.
+    # MCP_API_KEY) to reach it from other hosts — the entrypoint below refuses
+    # to start otherwise.
     ports:
       - "${MCP_BIND_ADDRESS:-127.0.0.1}:${MCP_PORT:-8080}:8080"
+    # Refuse to start if MCP_BIND_ADDRESS opts into a non-local bind without
+    # MCP_API_KEY set — that combination is an unauthenticated HTTP endpoint
+    # exposed beyond localhost. Local-only binding (the default) is unaffected.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        if [ "$$MCP_TRANSPORT" = "http" ] && [ "$$MCP_BIND_ADDRESS" != "127.0.0.1" ] && [ -z "$$MCP_API_KEY" ]; then
+          echo "MCP_BIND_ADDRESS=$$MCP_BIND_ADDRESS exposes the MCP server beyond localhost, but MCP_API_KEY is unset. Refusing to start an unauthenticated HTTP endpoint on the network. Set MCP_API_KEY in .env, or leave MCP_BIND_ADDRESS at 127.0.0.1." >&2
+          exit 1
+        fi
+        exec node dist/index.js
     environment:
       - NODE_ENV=production
       - MCP_TRANSPORT=${MCP_TRANSPORT:-http}
       - MCP_PORT=8080
       - MCP_API_KEY=${MCP_API_KEY:-}
+      - MCP_BIND_ADDRESS=${MCP_BIND_ADDRESS:-127.0.0.1}
       - FALKORDB_HOST=falkordb
       # Fixed at 6379: this is the in-network port the falkordb service listens
       # on. FALKORDB_PORT only remaps the *host* published port (see above), so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     # auth when MCP_API_KEY is set, so a wildcard bind would expose an
     # unauthenticated endpoint. Set MCP_BIND_ADDRESS=0.0.0.0 in .env (and set
     # MCP_API_KEY) to reach it from other hosts — the server itself refuses to
-    # start otherwise (see enforceLocalBindWithoutApiKey() in src/index.ts).
+    # start otherwise (see enforceLocalBindWithoutApiKey() in src/utils/startup-guard.ts).
     ports:
       - "${MCP_BIND_ADDRESS:-127.0.0.1}:${MCP_PORT:-8080}:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        if [ "$$MCP_TRANSPORT" = "http" ] && [ "$$MCP_BIND_ADDRESS" != "127.0.0.1" ] && [ -z "$$MCP_API_KEY" ]; then
+        if [ "$$MCP_TRANSPORT" = "http" ] && [ "$$MCP_BIND_ADDRESS" != "127.0.0.1" ] && [ "$$MCP_BIND_ADDRESS" != "::1" ] && [ -z "$$MCP_API_KEY" ]; then
           echo "MCP_BIND_ADDRESS=$$MCP_BIND_ADDRESS exposes the MCP server beyond localhost, but MCP_API_KEY is unset. Refusing to start an unauthenticated HTTP endpoint on the network. Set MCP_API_KEY in .env, or leave MCP_BIND_ADDRESS at 127.0.0.1." >&2
           exit 1
         fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,9 @@ services:
         exec /var/lib/falkordb/bin/run.sh
     ports:
       - "${FALKORDB_PORT:-6379}:6379"
-      # Web UI bound to 127.0.0.1 by default: it has no auth of its own, so a
-      # wildcard bind would expose it to the network. Override to reach it
-      # remotely (e.g. "0.0.0.0:${FALKORDB_WEB_PORT:-3000}:3000").
-      - "127.0.0.1:${FALKORDB_WEB_PORT:-3000}:3000"
+      # Web UI has no auth of its own, so it's bound to 127.0.0.1 by default.
+      # Set FALKORDB_WEB_BIND_ADDRESS=0.0.0.0 in .env to reach it remotely.
+      - "${FALKORDB_WEB_BIND_ADDRESS:-127.0.0.1}:${FALKORDB_WEB_PORT:-3000}:3000"
     volumes:
       - falkordb-data:/data
     networks:
@@ -50,12 +49,12 @@ services:
     # the in-container MCP_PORT must both stay 8080 — otherwise the host port
     # forwards to a port nothing is listening on and every connection is reset.
     #
-    # Published to 127.0.0.1 by default: in HTTP mode the server only enforces
-    # Bearer auth when MCP_API_KEY is set, so a wildcard bind would expose an
-    # unauthenticated endpoint. To reach it from other hosts, set MCP_API_KEY
-    # and override the binding (e.g. "0.0.0.0:${MCP_PORT:-8080}:8080").
+    # Bound to 127.0.0.1 by default: in HTTP mode the server only enforces Bearer
+    # auth when MCP_API_KEY is set, so a wildcard bind would expose an
+    # unauthenticated endpoint. Set MCP_BIND_ADDRESS=0.0.0.0 in .env (and set
+    # MCP_API_KEY) to reach it from other hosts.
     ports:
-      - "127.0.0.1:${MCP_PORT:-8080}:8080"
+      - "${MCP_BIND_ADDRESS:-127.0.0.1}:${MCP_PORT:-8080}:8080"
     environment:
       - NODE_ENV=production
       - MCP_TRANSPORT=${MCP_TRANSPORT:-http}

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -23,6 +23,7 @@ describe('Config', () => {
     expect(config).toHaveProperty('mcp');
     expect(config.mcp).toHaveProperty('transport');
     expect(config.mcp).toHaveProperty('apiKey');
+    expect(config.mcp).toHaveProperty('bindAddress');
     expect(['stdio', 'http']).toContain(config.mcp.transport);
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,6 +26,6 @@ export const config = {
   mcp: {
     transport: (process.env.MCP_TRANSPORT || 'stdio') as 'stdio' | 'http',
     apiKey: process.env.MCP_API_KEY || '',
-    bindAddress: process.env.MCP_BIND_ADDRESS || '',
+    bindAddress: process.env.MCP_BIND_ADDRESS || '127.0.0.1',
   },
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,5 +21,6 @@ export const config = {
   mcp: {
     transport: (process.env.MCP_TRANSPORT || 'stdio') as 'stdio' | 'http',
     apiKey: process.env.MCP_API_KEY || '',
+    bindAddress: process.env.MCP_BIND_ADDRESS || '',
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { errorHandler } from './errors/ErrorHandler.js';
 import { logger } from './services/logger.service.js';
 import { config } from './config/index.js';
-import { isLocalBindAddress } from './utils/bind-address.js';
+import { enforceLocalBindWithoutApiKey } from './utils/startup-guard.js';
 import registerAllTools from './mcp/tools.js';
 import registerAllResources from './mcp/resources.js';
 import registerAllPrompts from './mcp/prompts.js';
@@ -100,33 +100,6 @@ async function initializeServices(): Promise<void> {
   } catch (error) {
     await logger.error('Failed to initialize services', error instanceof Error ? error : new Error(String(error)));
     throw error;
-  }
-}
-
-// Refuse to start an HTTP transport that's published beyond localhost with no
-// API key set — that combination is an unauthenticated endpoint exposed to
-// the network. Local-only binding (the default) is unaffected. Runs before
-// initializeServices() so we don't open a FalkorDB connection we're about to
-// abandon, and exits directly rather than throwing: a throw here would be
-// caught by startServer()'s own try/catch below and routed through
-// gracefulShutdown(), which exits 0 on its success path.
-function enforceLocalBindWithoutApiKey(): void {
-  if (
-    config.mcp.transport === 'http' &&
-    !isLocalBindAddress(config.mcp.bindAddress) &&
-    !config.mcp.apiKey
-  ) {
-    const message = `MCP_BIND_ADDRESS=${config.mcp.bindAddress} exposes the MCP server beyond localhost, but MCP_API_KEY is unset. Refusing to start an unauthenticated HTTP endpoint on the network. Set MCP_API_KEY in .env, or leave MCP_BIND_ADDRESS at 127.0.0.1.`;
-    // logger.errorSync() alone isn't enough here: by default (production,
-    // ENABLE_FILE_LOGGING unset) it neither writes to a log file nor has an
-    // MCP client connected yet to notify, so the message would go nowhere —
-    // silently, worse than the shell guard this replaces, whose `echo >&2`
-    // was always visible in `docker compose logs`. console.error() writes to
-    // stderr directly, which is safe here regardless of transport: the stdio
-    // protocol only uses stdout, and startup hasn't reached HTTP yet either.
-    console.error(message);
-    logger.errorSync(message);
-    process.exit(1);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { errorHandler } from './errors/ErrorHandler.js';
 import { logger } from './services/logger.service.js';
 import { config } from './config/index.js';
+import { isLocalBindAddress } from './utils/bind-address.js';
 import registerAllTools from './mcp/tools.js';
 import registerAllResources from './mcp/resources.js';
 import registerAllPrompts from './mcp/prompts.js';
@@ -102,11 +103,40 @@ async function initializeServices(): Promise<void> {
   }
 }
 
+// Refuse to start an HTTP transport that's published beyond localhost with no
+// API key set — that combination is an unauthenticated endpoint exposed to
+// the network. Local-only binding (the default) is unaffected. Runs before
+// initializeServices() so we don't open a FalkorDB connection we're about to
+// abandon, and exits directly rather than throwing: a throw here would be
+// caught by startServer()'s own try/catch below and routed through
+// gracefulShutdown(), which exits 0 on its success path.
+function enforceLocalBindWithoutApiKey(): void {
+  if (
+    config.mcp.transport === 'http' &&
+    !isLocalBindAddress(config.mcp.bindAddress) &&
+    !config.mcp.apiKey
+  ) {
+    const message = `MCP_BIND_ADDRESS=${config.mcp.bindAddress} exposes the MCP server beyond localhost, but MCP_API_KEY is unset. Refusing to start an unauthenticated HTTP endpoint on the network. Set MCP_API_KEY in .env, or leave MCP_BIND_ADDRESS at 127.0.0.1.`;
+    // logger.errorSync() alone isn't enough here: by default (production,
+    // ENABLE_FILE_LOGGING unset) it neither writes to a log file nor has an
+    // MCP client connected yet to notify, so the message would go nowhere —
+    // silently, worse than the shell guard this replaces, whose `echo >&2`
+    // was always visible in `docker compose logs`. console.error() writes to
+    // stderr directly, which is safe here regardless of transport: the stdio
+    // protocol only uses stdout, and startup hasn't reached HTTP yet either.
+    console.error(message);
+    logger.errorSync(message);
+    process.exit(1);
+  }
+}
+
 // Main server startup
 async function startServer(): Promise<void> {
+  enforceLocalBindWithoutApiKey();
+
   try {
     await initializeServices();
-    
+
     if (config.mcp.transport === 'http') {
       await startHTTPServer();
     } else {

--- a/src/services/falkordb.service.ts
+++ b/src/services/falkordb.service.ts
@@ -93,7 +93,7 @@ class FalkorDBService {
         } else {
           const appError = new AppError(
             CommonErrors.CONNECTION_FAILED,
-            `Failed to connect to FalkorDB after ${this.maxRetries} attempts: ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to connect to FalkorDB after ${this.maxRetries + 1} attempts: ${error instanceof Error ? error.message : String(error)}`,
             true
           );
 

--- a/src/services/falkordb.service.ts
+++ b/src/services/falkordb.service.ts
@@ -84,6 +84,11 @@ class FalkorDBService {
           });
 
           const delay = Math.min(5000 * 2 ** this.retryCount, 30000) + Math.random() * 1000;
+
+          console.error(
+            `[FalkorDB] Connection attempt ${this.retryCount + 1}/${this.maxRetries + 1} failed, retrying in ${Math.round(delay / 1000)}s...`
+          );
+
           await new Promise(resolve => setTimeout(resolve, delay));
         } else {
           const appError = new AppError(
@@ -91,8 +96,9 @@ class FalkorDBService {
             `Failed to connect to FalkorDB after ${this.maxRetries} attempts: ${error instanceof Error ? error.message : String(error)}`,
             true
           );
-          
+
           await logger.error('FalkorDB connection failed permanently', appError);
+          console.error(`[FalkorDB] ${appError.message}`);
           throw appError;
         }
       }

--- a/src/utils/bind-address.test.ts
+++ b/src/utils/bind-address.test.ts
@@ -1,4 +1,4 @@
-import { isLocalBindAddress } from './bind-address';
+import { isLocalBindAddress, isUnauthenticatedNetworkExposure } from './bind-address';
 
 describe('Bind Address Utility', () => {
   describe('isLocalBindAddress', () => {
@@ -35,6 +35,38 @@ describe('Bind Address Utility', () => {
       it.each(nonLocalValues)('treats %s as non-local', (value) => {
         expect(isLocalBindAddress(value)).toBe(false);
       });
+    });
+  });
+
+  describe('isUnauthenticatedNetworkExposure', () => {
+    it('is true for a non-local HTTP bind with no API key', () => {
+      expect(
+        isUnauthenticatedNetworkExposure({ transport: 'http', bindAddress: '0.0.0.0', apiKey: '' })
+      ).toBe(true);
+    });
+
+    it('is false for a non-local HTTP bind with an API key set', () => {
+      expect(
+        isUnauthenticatedNetworkExposure({ transport: 'http', bindAddress: '0.0.0.0', apiKey: 'secret' })
+      ).toBe(false);
+    });
+
+    it('is false for a local HTTP bind with no API key', () => {
+      expect(
+        isUnauthenticatedNetworkExposure({ transport: 'http', bindAddress: '127.0.0.1', apiKey: '' })
+      ).toBe(false);
+    });
+
+    it('is false for a non-local bind with no API key when transport is stdio', () => {
+      expect(
+        isUnauthenticatedNetworkExposure({ transport: 'stdio', bindAddress: '0.0.0.0', apiKey: '' })
+      ).toBe(false);
+    });
+
+    it('is false when bindAddress is unset (defaults to local)', () => {
+      expect(
+        isUnauthenticatedNetworkExposure({ transport: 'http', bindAddress: undefined, apiKey: '' })
+      ).toBe(false);
     });
   });
 });

--- a/src/utils/bind-address.test.ts
+++ b/src/utils/bind-address.test.ts
@@ -1,0 +1,40 @@
+import { isLocalBindAddress } from './bind-address';
+
+describe('Bind Address Utility', () => {
+  describe('isLocalBindAddress', () => {
+    describe('local addresses', () => {
+      const localValues = [
+        '127.0.0.1', // default loopback
+        '127.0.0.2', // other 127.0.0.0/8 loopback
+        '127.255.255.255', // top of the 127.0.0.0/8 range
+        '::1', // bare IPv6 loopback
+        '[::1]', // bracketed IPv6 loopback
+        '::ffff:127.0.0.1', // IPv4-mapped IPv6 loopback
+        '  127.0.0.1  ', // loopback with surrounding whitespace
+        '', // empty string (unset)
+        undefined, // undefined (unset)
+      ];
+
+      it.each(localValues)('treats %s as local', (value) => {
+        expect(isLocalBindAddress(value)).toBe(true);
+      });
+    });
+
+    describe('non-local addresses', () => {
+      const nonLocalValues = [
+        '0.0.0.0', // wildcard IPv4
+        '::', // wildcard IPv6
+        '192.168.1.10', // LAN address
+        '10.0.0.5', // private network address
+        '8.8.8.8', // public address
+        'localhost', // hostname (Compose itself rejects this)
+        'not-an-ip', // garbage input
+        '128.0.0.1', // address that merely starts with a similar prefix
+      ];
+
+      it.each(nonLocalValues)('treats %s as non-local', (value) => {
+        expect(isLocalBindAddress(value)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/utils/bind-address.test.ts
+++ b/src/utils/bind-address.test.ts
@@ -1,4 +1,4 @@
-import { isLocalBindAddress, isUnauthenticatedNetworkExposure } from './bind-address';
+import { isLocalBindAddress, isUnauthenticatedNetworkExposure } from './bind-address.js';
 
 describe('Bind Address Utility', () => {
   describe('isLocalBindAddress', () => {

--- a/src/utils/bind-address.test.ts
+++ b/src/utils/bind-address.test.ts
@@ -30,6 +30,11 @@ describe('Bind Address Utility', () => {
         'localhost', // hostname (Compose itself rejects this)
         'not-an-ip', // garbage input
         '128.0.0.1', // address that merely starts with a similar prefix
+        '127.999.999.999', // out-of-range octets shaped like an IPv4 address
+        '127.0.0.256', // out-of-range last octet
+        '127.00.0.1', // leading zero (historically parsed as octal)
+        '::ffff:999.0.0.1', // IPv4-mapped form with an invalid embedded octet
+        '127.0.0.1.5', // too many octets
       ];
 
       it.each(nonLocalValues)('treats %s as non-local', (value) => {

--- a/src/utils/bind-address.ts
+++ b/src/utils/bind-address.ts
@@ -2,6 +2,8 @@
  * Utility to classify a Docker bind-address value as local (loopback) or not.
  */
 
+import { isIPv4 } from 'net';
+
 /**
  * Determine whether a bind-address value (as set via MCP_BIND_ADDRESS) refers
  * to a loopback interface — i.e. one that is not reachable from outside the
@@ -42,10 +44,11 @@ export function isLocalBindAddress(value: string | undefined): boolean {
   const ipv4MappedMatch = unbracketed.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
   const ipv4Candidate = ipv4MappedMatch ? ipv4MappedMatch[1] : unbracketed;
 
-  const ipv4Match = ipv4Candidate.match(/^(\d{1,3})\.\d{1,3}\.\d{1,3}\.\d{1,3}$/);
-  if (ipv4Match) {
-    const firstOctet = parseInt(ipv4Match[1], 10);
-    return firstOctet === 127;
+  // isIPv4() validates every octet (0-255, no leading zeros), unlike a shape-only
+  // regex — so garbage like `127.999.999.999` or octal-looking `127.00.0.1` is
+  // correctly rejected rather than classified as loopback.
+  if (isIPv4(ipv4Candidate)) {
+    return ipv4Candidate.startsWith('127.');
   }
 
   return false;

--- a/src/utils/bind-address.ts
+++ b/src/utils/bind-address.ts
@@ -1,0 +1,52 @@
+/**
+ * Utility to classify a Docker bind-address value as local (loopback) or not.
+ */
+
+/**
+ * Determine whether a bind-address value (as set via MCP_BIND_ADDRESS) refers
+ * to a loopback interface — i.e. one that is not reachable from outside the
+ * host it's running on.
+ *
+ * Accepts:
+ *  - unset/empty (treated as "not opted in", so it's safe)
+ *  - `127.0.0.0/8` in either bracketed or unbracketed form
+ *  - `::1`, bracketed as `[::1]` or not (Docker Compose's `host_ip` accepts both)
+ *  - IPv4-mapped loopback, e.g. `::ffff:127.0.0.1`
+ *
+ * Deliberately does NOT special-case `localhost`: Docker Compose rejects it
+ * outright as an invalid `host_ip` before the container ever starts, so
+ * accepting it here would just invite unverifiable hostname assumptions.
+ *
+ * Everything else — including `0.0.0.0`, `::`, and any LAN/public address —
+ * is treated as non-local (fails closed).
+ *
+ * @param value The raw MCP_BIND_ADDRESS value.
+ * @returns true if the value is a loopback address (or unset).
+ */
+export function isLocalBindAddress(value: string | undefined): boolean {
+  const normalized = (value ?? '').trim();
+
+  if (normalized === '') {
+    return true;
+  }
+
+  // Compose's host_ip accepts IPv6 literals bracketed (e.g. "[::1]") or bare.
+  const unbracketed = normalized.startsWith('[') && normalized.endsWith(']')
+    ? normalized.slice(1, -1)
+    : normalized;
+
+  if (unbracketed === '::1') {
+    return true;
+  }
+
+  const ipv4MappedMatch = unbracketed.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
+  const ipv4Candidate = ipv4MappedMatch ? ipv4MappedMatch[1] : unbracketed;
+
+  const ipv4Match = ipv4Candidate.match(/^(\d{1,3})\.\d{1,3}\.\d{1,3}\.\d{1,3}$/);
+  if (ipv4Match) {
+    const firstOctet = parseInt(ipv4Match[1], 10);
+    return firstOctet === 127;
+  }
+
+  return false;
+}

--- a/src/utils/bind-address.ts
+++ b/src/utils/bind-address.ts
@@ -50,3 +50,27 @@ export function isLocalBindAddress(value: string | undefined): boolean {
 
   return false;
 }
+
+interface McpHttpAuthConfig {
+  transport: string;
+  bindAddress: string | undefined;
+  apiKey: string | undefined;
+}
+
+/**
+ * Determine whether MCP's HTTP transport would be published on a non-local
+ * address with no API key protecting it — an unauthenticated endpoint
+ * exposed to the network. Used to decide whether server startup should be
+ * refused; kept separate from that side effect so the decision itself is
+ * unit-testable.
+ *
+ * @param mcpConfig The relevant slice of `config.mcp`.
+ * @returns true if the server would be exposed with no auth.
+ */
+export function isUnauthenticatedNetworkExposure(mcpConfig: McpHttpAuthConfig): boolean {
+  return (
+    mcpConfig.transport === 'http' &&
+    !isLocalBindAddress(mcpConfig.bindAddress) &&
+    !mcpConfig.apiKey
+  );
+}

--- a/src/utils/bind-address.ts
+++ b/src/utils/bind-address.ts
@@ -74,6 +74,6 @@ export function isUnauthenticatedNetworkExposure(mcpConfig: McpHttpAuthConfig): 
   return (
     mcpConfig.transport === 'http' &&
     !isLocalBindAddress(mcpConfig.bindAddress) &&
-    !mcpConfig.apiKey
+    !(mcpConfig.apiKey ?? '').trim()
   );
 }

--- a/src/utils/startup-guard.test.ts
+++ b/src/utils/startup-guard.test.ts
@@ -1,0 +1,87 @@
+// Mock the logger service
+jest.mock('../services/logger.service.js', () => ({
+  logger: {
+    errorSync: jest.fn(),
+  }
+}));
+
+// Mock config with a mutable object so each test can vary it
+let mockConfig = {
+  mcp: {
+    transport: 'stdio' as 'stdio' | 'http',
+    apiKey: '',
+    bindAddress: '',
+  },
+};
+
+jest.mock('../config/index.js', () => ({
+  get config() {
+    return mockConfig;
+  }
+}));
+
+// Import after mocks are set up
+import { enforceLocalBindWithoutApiKey } from './startup-guard.js';
+import { logger } from '../services/logger.service.js';
+
+describe('Startup Guard', () => {
+  let processExitSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfig = {
+      mcp: {
+        transport: 'stdio',
+        apiKey: '',
+        bindAddress: '',
+      },
+    };
+    processExitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('enforceLocalBindWithoutApiKey', () => {
+    it('exits 1 for a non-local HTTP bind with no API key', () => {
+      mockConfig.mcp = { transport: 'http', apiKey: '', bindAddress: '0.0.0.0' };
+
+      expect(() => enforceLocalBindWithoutApiKey()).toThrow('process.exit called');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('MCP_BIND_ADDRESS=0.0.0.0'));
+      expect(logger.errorSync).toHaveBeenCalledWith(expect.stringContaining('MCP_API_KEY'));
+    });
+
+    it('does not exit for a non-local HTTP bind with an API key set', () => {
+      mockConfig.mcp = { transport: 'http', apiKey: 'secret', bindAddress: '0.0.0.0' };
+
+      expect(() => enforceLocalBindWithoutApiKey()).not.toThrow();
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not exit for a local HTTP bind with no API key', () => {
+      mockConfig.mcp = { transport: 'http', apiKey: '', bindAddress: '127.0.0.1' };
+
+      expect(() => enforceLocalBindWithoutApiKey()).not.toThrow();
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not exit for stdio transport regardless of bind address or API key', () => {
+      mockConfig.mcp = { transport: 'stdio', apiKey: '', bindAddress: '0.0.0.0' };
+
+      expect(() => enforceLocalBindWithoutApiKey()).not.toThrow();
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/startup-guard.ts
+++ b/src/utils/startup-guard.ts
@@ -1,0 +1,33 @@
+import { config } from '../config/index.js';
+import { logger } from '../services/logger.service.js';
+import { isUnauthenticatedNetworkExposure } from './bind-address.js';
+
+/**
+ * Refuse to start an HTTP transport that's published beyond localhost with no
+ * API key set — that combination is an unauthenticated endpoint exposed to
+ * the network. Local-only binding (the default) is unaffected. Call before
+ * initializing any other services, so a refusal doesn't first open a
+ * FalkorDB connection it's about to abandon.
+ *
+ * Exits directly rather than throwing: a throw from inside startServer()'s
+ * try/catch would be routed through gracefulShutdown(), which exits 0 on its
+ * success path — turning a startup refusal into a reported success.
+ */
+export function enforceLocalBindWithoutApiKey(): void {
+  if (!isUnauthenticatedNetworkExposure(config.mcp)) {
+    return;
+  }
+
+  const message = `MCP_BIND_ADDRESS=${config.mcp.bindAddress} exposes the MCP server beyond localhost, but MCP_API_KEY is unset. Refusing to start an unauthenticated HTTP endpoint on the network. Set MCP_API_KEY in .env, or leave MCP_BIND_ADDRESS at 127.0.0.1.`;
+
+  // logger.errorSync() alone isn't enough here: by default (production,
+  // ENABLE_FILE_LOGGING unset) it neither writes to a log file nor has an
+  // MCP client connected yet to notify, so the message would go nowhere —
+  // silently, worse than the shell guard this replaces, whose `echo >&2`
+  // was always visible in `docker compose logs`. console.error() writes to
+  // stderr directly, which is safe here regardless of transport: the stdio
+  // protocol only uses stdout, and startup hasn't reached HTTP yet either.
+  console.error(message);
+  logger.errorSync(message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Context

**Order of operations, since this spans several commits on #123 before landing here:**

1. #123's first commit ([`f980757`](https://github.com/FalkorDB/FalkorDB-MCPServer/commit/f98a0757629defa249006ab149f0b815d43230cd)) switched the Docker default MCP transport to HTTP and published the port without restricting the bind address, with auth as an optional extra (empty `MCP_API_KEY` was allowed). This is what put an unauthenticated-capable listener on the network in the first place.
2. CodeRabbit reviewed that PR while it was open and flagged exactly this, suggesting two separate fixes, either one would have addressed it:

   > "The docker-compose defaults currently start MCP in HTTP mode with an empty API key, which can expose an unauthenticated host-published listener... either require MCP_API_KEY before enabling HTTP or bind the published port to localhost by default."

3. In response, a **follow-up commit pushed to the same #123 branch** — [`9ff305f`](https://github.com/FalkorDB/FalkorDB-MCPServer/commit/9ff305f1172e5dd910bcaeb02dc431d2beec5130) ("address review — localhost bind, fixed FalkorDB port, accurate env docs") — is the one that actually closed off network access. It took CodeRabbit's second option, but implemented it by hardcoding `127.0.0.1` with no override anywhere. A third commit on that same PR, [`b2e6d3f`](https://github.com/FalkorDB/FalkorDB-MCPServer/commit/b2e6d3fc60fa3d74ad9b3fe49363033e61199d0), extended the same hardcoded lockdown to the FalkorDB web UI port. All three commits merged together as a single PR, #123.

**Why `9ff305f` was overly aggressive:** CodeRabbit's comment asked for a safe *default*, not for exposure to be made impossible. Hardcoding `127.0.0.1` with no override went further than that: it doesn't just default to a safe state, it removes remote access as a possibility at all, short of hand-editing `docker-compose.yml`. Remote access to FalkorDB (over a LAN, from another machine) is a valid use case, and this PR is what happens when someone actually needs it and finds there's no supported way to get it.

**How this differs from what #123 replaced:** the pre-#123 version was open by default with auth as optional, so reaching the insecure state took no action. This PR keeps the safe default `9ff305f` chose (`127.0.0.1`, unchanged), and only makes it configurable again: exposing either service now requires deliberately setting `MCP_BIND_ADDRESS=0.0.0.0` or `FALKORDB_WEB_BIND_ADDRESS=0.0.0.0` in `.env`.

**Why this isn't just reintroducing the old risk:** binding to localhost by default is a starting value, not enforcement, on its own it doesn't stop someone from opting into `0.0.0.0` without also setting `MCP_API_KEY`, which recreates the exact unauthenticated-listener scenario CodeRabbit flagged. I checked the code: the Bearer-auth check in `src/index.ts` is a silent no-op when `MCP_API_KEY` is empty. So this PR also implements CodeRabbit's other suggested fix, requiring an API key before HTTP is exposed, scoped to exactly the case where it matters: the `falkordb-mcpserver` entrypoint now refuses to start if `MCP_TRANSPORT=http`, the bind address isn't `127.0.0.1`, and `MCP_API_KEY` is unset. It logs why and exits instead of quietly serving unauthenticated requests. The default setup (local-only, no key) starts exactly as before.

This guard only covers MCP, since it's the only service here with an auth mechanism to check against. The web UI has none at all, so `FALKORDB_WEB_BIND_ADDRESS` stays a documentation-only warning, same as it was after `b2e6d3f`. (The raw FalkorDB database port, 6379, is a separate case: it's never been bind-restricted, by #123 or otherwise, and it's already gated by real auth, `FALKORDB_PASSWORD`/ACL, so it's out of scope here.)

## Changes

- `FALKORDB_WEB_BIND_ADDRESS` and `MCP_BIND_ADDRESS`, both default to `127.0.0.1`
- `falkordb-mcpserver` refuses to start on a non-local bind with no API key set
- `.env.example` documents both, with a clear note on what opting in means

## Test plan
- [x] `docker compose config` validates
- [x] Default settings: both ports bind `127.0.0.1`, server starts normally
- [x] `MCP_BIND_ADDRESS=0.0.0.0`, no API key: refuses to start, clear error in logs
- [x] `MCP_BIND_ADDRESS=0.0.0.0`, API key set: starts normally, reachable (`401` as expected)
- [x] `FALKORDB_WEB_BIND_ADDRESS=0.0.0.0`: confirmed reachable from a remote host
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (135 passing)

Fixes #178



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable bind addresses for the MCP server and FalkorDB web UI, defaulting to localhost.
* **Bug Fixes**
  * The MCP server now refuses non-local HTTP binding without an API key.
  * Improved validation of local bind addresses.
  * Improved visibility and accuracy of FalkorDB connection retry and failure messages.
* **Documentation**
  * Updated transport, authentication, HTTP security, Docker Compose, reverse-proxy, and environment variable guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->